### PR TITLE
add /_health and /_version URLs to server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An API that returns public data from the Verida network",
   "main": "dist/server.js",
   "scripts": {
+    "prebuild": "echo 'export const Version = { version: \"'$npm_package_version'\", build_utc: \"'$(date -u -Iseconds)'\" };' > ./src/version.ts",
     "dev": "yarn build; nodemon src/server.js",
     "build": "rm -rf dist && tsc",
     "prestart": "yarn build",

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,7 +13,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: prod
   region: us-east-1
  

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,7 +1,14 @@
-import express from 'express'
-import Controller from './controller'
+import express from 'express';
+import Controller from './controller';
+import UtilsController from './utils-controller';
 
 const router = express.Router()
+
+const utilsController = new UtilsController();
+
+
+router.get("/_health", (req, res) => utilsController.getHealth(req, res));
+router.get("/_version", (req, res) => utilsController.getVersion(req, res));
 
 router.get(/^\/network\/(.*)\/stats$/, Controller.stats)
 router.get(/^\/$/, Controller.home)
@@ -14,5 +21,7 @@ router.get(/^\/ipfs\/(.*)/, Controller.getIPFS)
 // /<base58EncodedVeridaUri>
 // @see @verida/helpers Utils.encodeUri()
 router.get(/^\/(.*)?$/, Controller.getUri)
+
+
 
 export default router

--- a/src/utils-controller.ts
+++ b/src/utils-controller.ts
@@ -1,0 +1,69 @@
+import { Request, Response } from "express";
+import { Version } from "./version.js";
+
+export interface HealthCheck {
+  /**
+   * @summary A method that checks that this API Provider is working
+   *
+   * Implementations are free to perform whatever checks they need, but performance should
+   * be considered. As a guideline, 2s is acceptable but 10s is not.
+   *
+   * @param address Address of the string whose Nonce is to be fetched.
+   *
+   * @returns any
+   */
+  checkHealth(): Promise<APIHealthResult>;
+}
+
+export interface APIHealthResult {
+  working: boolean;
+  message?: string;
+}
+
+
+export default class UtilsController {
+  public constructor() {}
+
+  /**
+   * @summary Get Health API
+   *
+   * Check that all APIs appear to be reachable and running
+   *
+   * This is by no means a comprehensive test of the APIs we call.
+   * We just want to be sure we can connect succesfully and get some basic data
+   *
+   * @type GET
+   *
+   * @param {Request} Express request
+   * @param {Response} Express response
+   *
+   * @returns {Promise<Response<APIHealthResult>>}
+   */
+  public async getHealth(req: Request, res: Response): Promise<Response<APIHealthResult>> {
+    return res.status(200).send({
+      status: "success",
+      data: {working: true},
+    });
+  }
+
+  /**
+   * @summary Get deployed version
+   *
+   * @type GET
+   *
+   * @param {Request} Express request
+   * @param {Response} Express response
+   *
+   * @returns {Promise<SupportedTokenObject>}
+   */
+  public getVersion(req: Request, res: Response): Response {
+    return res.status(200).send({
+      status: "success",
+      data: {
+        version: Version.version,
+        build_time_utc: Version.build_utc,
+      },
+    });
+  }
+
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const Version = { version: "0.1.0", build_utc: "2023-05-10T04:58:18+00:00" };


### PR DESCRIPTION
adds a  `/_health` and `/_version` URL to the server (I'm trying to do this for all our servers).

The `/_health` one doesn't actually do anything except returns, but it would detect bad deployments at least.. 